### PR TITLE
feat: replace panic errors with Result::Err

### DIFF
--- a/src/killer.rs
+++ b/src/killer.rs
@@ -155,7 +155,7 @@ mod killer_tests {
         let used_port = random_take_up_port();
         assert!(!is_free(used_port));
         let pids = killer.get_pid(used_port).unwrap();
-        let res = killer.kill(pids);
+        let _ = killer.kill(pids);
         assert!(is_free(used_port));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,32 +1,30 @@
-use std::io::Error;
-
 use killer::{Killer, Unix, Win};
 
 mod killer;
 
-pub fn kill(port: u16) -> Result<bool, Error> {
+pub fn kill(port: u16) -> Result<bool, String> {
     let killer = if cfg!(target_os = "windows") {
         Box::new(Win) as Box<dyn Killer>
     } else {
         Box::new(Unix) as Box<dyn Killer>
     };
-    let pids = killer
-        .get_pid(port)
-        .unwrap_or_else(|e| panic!("Failed to get pids on port: {}, error: {}", port, e));
-    Ok(killer
-        .kill(pids)
-        .unwrap_or_else(|e| panic!("Failed to kill process on port: {}, error: {}", port, e)))
+
+    match killer.get_pid(port) {
+        Ok(pids) => kill_by_pids(&pids),
+        Err(error) => Result::Err(format!("Failed to get pids on port: {}, error: {}", port, error)),
+    }
 }
 
-pub fn kill_by_pids(pids: &[u32]) -> Result<bool, Error> {
+pub fn kill_by_pids(pids: &[u32]) -> Result<bool, String> {
     let killer = if cfg!(target_os = "windows") {
         Box::new(Win) as Box<dyn Killer>
     } else {
         Box::new(Unix) as Box<dyn Killer>
     };
-    Ok(killer
-        .kill(pids.to_vec())
-        .unwrap_or_else(|e| panic!("Failed to kill process on pids: {:#?}, Error: {}", pids, e)))
+    match killer.kill(pids.to_vec()) {
+        Ok(result) => Ok(result),
+        Err(error) => Err(format!("Failed to kill process on pids: {:#?}, Error: {}", pids, error)),
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Hello, I think it would be universally better to get `Result::Err` when killer was not able to kill anything.